### PR TITLE
hot fix type error MINIMUN on estimated accuracy valuation view

### DIFF
--- a/components/Valuation/EstimateAccuracy.tsx
+++ b/components/Valuation/EstimateAccuracy.tsx
@@ -68,7 +68,7 @@ const EstimateAccuracy = ({ metaverse }: Props) => {
               MAXIMUM :
             </p>
             <p className={styleContent}>
-              MINIMUN :
+              MINIMUM :
             </p>
           </div>
           <div className="items-end space-y-1 text-right">


### PR DESCRIPTION
- Hot fix gived by Camilo Echevery:

Type error MINIMUN to MINIMUM

![image](https://user-images.githubusercontent.com/54643793/224701434-4ba4dd7e-634a-4b5b-9d4e-892528c05d0e.png)
