### PR TITLE
Pr/header and data boxes update by bonnie

### DIFF
--- a/components/Analytics/AnalyticsChart.tsx
+++ b/components/Analytics/AnalyticsChart.tsx
@@ -18,6 +18,7 @@ interface Props {
   data: ChartData[]
   fetching: boolean
   label: string
+  smallSize?: boolean
   backgroundHexa?: string
 }
 
@@ -27,7 +28,8 @@ const AnalyticsChart = ({
   metaverse,
   prices,
   fetching,
-  backgroundHexa
+  backgroundHexa,
+  smallSize
 }: Props) => {
   const [symbol, setSymbol] = useState<keyof typeof chartSymbolOptions>('ETH')
   const intervalLabels = {
@@ -53,7 +55,7 @@ const AnalyticsChart = ({
     if (!chartElement.current) return
     const chart = createChart(chartElement.current, {
       width: chartElement.current.clientWidth,
-      height: 197,
+      height: smallSize ? 103 : 197,
       timeScale: {
         fixLeftEdge: true,
         fixRightEdge: true,

--- a/components/Valuation/HistoricalFloorPrice.tsx
+++ b/components/Valuation/HistoricalFloorPrice.tsx
@@ -5,8 +5,6 @@ import { ICoinPrices } from "../../lib/valuation/valuationTypes"
 
 import { AnalyticsChart } from "../Analytics"
 import { fetchChartData } from "../Analytics/fetchChartData"
-import { Tooltip } from "@mui/material"
-import { AiFillQuestionCircle } from "react-icons/ai"
 
 interface HistoricalFloorPriceProps {
   metaverse: Metaverse
@@ -62,6 +60,7 @@ const HistoricalFloorPrice = ({ metaverse, coinPrices }: HistoricalFloorPricePro
             metaverse={metaverse}
             prices={coinPrices}
             backgroundHexa={'#E9ECF6'}
+            smallSize
           />
         </div>
       </div>

--- a/pages/valuation.tsx
+++ b/pages/valuation.tsx
@@ -282,14 +282,14 @@ const Valuation: NextPage<{ prices: ICoinPrices }> = ({ prices }) => {
 			</Head>
 
 			{/* Top Padding or Image */}
-			<div className={`relative p-0 mb-24 w-full h-[400px]`}>
+			{metaverse ? <div className={`relative p-0 mb-24 w-full h-[400px]`}>
 				<Image
 					src="/images/land_header.png"
 					objectFit={'cover'}
 					alt='land header'
 					layout="fill"
 				/>
-			</div>
+			</div> : <div className="pt-32 w-full" />}
 
 			{/* General Section Layout */}
 			<GeneralSection
@@ -553,12 +553,12 @@ const Valuation: NextPage<{ prices: ICoinPrices }> = ({ prices }) => {
 						<>
 							<div className="flex items-center justify-center p-8 mt-7">
 								<div className="flex flex-col justify-center space-y-3 max-w-xl text-center">
-									<p className="text-grey-content font-bold lg:text-3xl text-2xl text-center">{metaverseLabels[metaverse]} Floor Listings <Image src='/images/icons/hot-icon.svg' width={24} height={26} alt="Hot Deals" className=''/></p>
+									<p className="text-grey-content font-bold lg:text-3xl text-2xl text-center">{metaverseLabels[metaverse]} Floor Listings <Image src='/images/icons/hot-icon.svg' width={24} height={26} alt="Hot Deals" className='' /></p>
 									<p className="font-medium text-cente">Undervalued floor listings</p>
 								</div>
 							</div>
 							<div className="flex items-center justify-center p-8 mt-7">
-								<HotDeals metaverse={metaverse}/>
+								<HotDeals metaverse={metaverse} />
 							</div>
 						</>
 					)}


### PR DESCRIPTION
Resize data boxes, this was achieved by adding a property to the small size graph

![image](https://user-images.githubusercontent.com/54643793/236566536-031ba905-9ff0-4098-aa13-dc8311abb890.png)

Removed the banner image when choosing the metaverse in land valuation, but it appears once a choice is made.

![image](https://user-images.githubusercontent.com/54643793/236566942-73e8f303-c0b9-4940-85ae-1e338694d2f3.png)

![image](https://user-images.githubusercontent.com/54643793/236567099-859103d3-6ed2-4aee-aa96-2ffe857754fa.png)

