### PR TITLE
Pr/tooltip for explanation valuation view

### DIFF
--- a/components/Heatmap/MapCard.tsx
+++ b/components/Heatmap/MapCard.tsx
@@ -1,6 +1,6 @@
-import { Alert, Snackbar } from "@mui/material";
+import { Alert, Snackbar, Tooltip } from "@mui/material";
 import { useEffect, useState } from "react";
-import { AiFillHeart, AiOutlineExpand } from "react-icons/ai";
+import { AiFillHeart, AiFillQuestionCircle, AiOutlineExpand } from "react-icons/ai";
 import { BsTwitter } from "react-icons/bs";
 import { IoClose } from "react-icons/io5";
 import { RiLoader3Fill } from "react-icons/ri";
@@ -97,12 +97,6 @@ const MapCard = ({
   // Shop Cart List controller
   const shopList = useSelector((state: any) => state.shopCartList)
   const [isOnShopCartList, setIsOnListSection] = useState<boolean>()
-  const handleShopCart = (action: 'add' | 'remove') => {
-    if (action === 'add')
-      dispatch(addToCart({ land: apiData, address: address }))
-    if (action === 'remove')
-      dispatch(removeFromCart({ land: apiData, address: address }))
-  }
 
   const options = SocialMediaOptions(
     apiData?.tokenId,
@@ -225,7 +219,28 @@ const MapCard = ({
                 )}
               </h3>
               <div>
-                <p className="text-sm text-grey-icon mb-3">Our Price Estimation:</p>
+                <div className="text-sm text-grey-icon mb-3 flex gap-2 items-center">
+                  Our Price Estimation:
+                  <Tooltip title={<span className="whitespace-pre-line">
+                    {`Stats
+										MAPE:
+										The Mean Absolute Percentage Error is the average forecast absolute error scaled to percentage units, where absolute errors allow to avoid the positive and negative errors cancelling.
+										R-Squared:
+										The R-Squared also known as coefficient of determination is the proportion of the variation between the forecasted valuations and actual selling prices. It ranges from 0 to 1 where 1 indicates the forcasted values match perfectly with actual values.
+										Maximum:
+										Maximum forecasted value that the trained model returns
+										Minimum:
+										Minimum forecasted value that the trained model returns
+									`}
+                  </span>}
+                    placement="bottom-start"
+                    arrow
+                  >
+                    <div>
+                      <AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />
+                    </div>
+                  </Tooltip>
+                </div>
                 {/* Price List */}
                 {predictions ? (
                   <div className="w-fit">

--- a/components/Valuation/EstimateAccuracy.tsx
+++ b/components/Valuation/EstimateAccuracy.tsx
@@ -62,8 +62,8 @@ const EstimateAccuracy = ({ metaverse }: Props) => {
           className='flex border-t border-l border-white/10 shadow-blck rounded-xl justify-between items-center p-5 min-w-max h-full bg-grey-panel'
         >
           <div className="flex flex-col space-y-1">
-            <div className='flex items-center gap-x-2 mb-4'>
-              <Tooltip title={'Mean Absolute Percentage Error'} placement="bottom-start" arrow>
+            <div className='flex items-center gap-x-2'>
+              <Tooltip title={'The Mean Absolute Percentage Error is the average forecast absolute error scaled to percentage units, where absolute errors allow to avoid the positive and negative errors cancelling.'} placement="bottom-start" arrow>
                 <div>
                   <AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />
                 </div>
@@ -72,8 +72,8 @@ const EstimateAccuracy = ({ metaverse }: Props) => {
                 MAPE :
               </p>
             </div>
-            <div className='flex items-center gap-x-2 mb-4'>
-              <Tooltip title={'coefficient of determination'} placement="bottom-start" arrow>
+            <div className='flex items-center gap-x-2'>
+              <Tooltip title={'The R-Squared also known as coefficient of determination is the proportion of the variation between the forecasted valuations and actual selling prices. It ranges from 0 to 1 where 1 indicates the forcasted values match perfectly with actual values.'} placement="bottom-start" arrow>
                 <div>
                   <AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />
                 </div>
@@ -82,7 +82,7 @@ const EstimateAccuracy = ({ metaverse }: Props) => {
                 R-Squared :
               </p>
             </div>
-            <div className='flex items-center gap-x-2 mb-4'>
+            <div className='flex items-center gap-x-2'>
               <Tooltip title={'Maximum forecasted value that the trained model returns'} placement="bottom-start" arrow>
                 <div>
                   <AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />
@@ -92,7 +92,7 @@ const EstimateAccuracy = ({ metaverse }: Props) => {
                 MAXIMUM :
               </p>
             </div>
-            <div className='flex items-center gap-x-2 mb-4'>
+            <div className='flex items-center gap-x-2'>
               <Tooltip title={'Minimum forecasted value that the trained model returns'} placement="bottom-start" arrow>
                 <div>
                   <AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />

--- a/pages/valuation.tsx
+++ b/pages/valuation.tsx
@@ -48,6 +48,8 @@ import ConnectButton from "../components/ConnectButton";
 import HotDeals from "../components/Valuation/HotDeals/HotDeals";
 import web3authService from "../backend/services/Web3authService";
 import { getCoingeckoPrices } from "../backend/services/openSeaDataManager";
+import { Tooltip } from "@mui/material";
+import { AiFillQuestionCircle } from "react-icons/ai";
 
 // Making this state as an object in order to iterate easily through it
 export const VALUATION_STATE_OPTIONS = [
@@ -313,7 +315,28 @@ const Valuation: NextPage<{ prices: ICoinPrices }> = ({ prices }) => {
 				</div>) : (<div >
 					{metaverse && <div className="flex items-center justify-between p-8 mt-7">
 						<div className="flex flex-col space-y-3 max-w-xl">
-							<p className="text-3xl font-semibold">{metaverseLabels[metaverse]}</p>
+							<div className="text-3xl font-semibold flex items-end gap-2">
+								{metaverseLabels[metaverse]}
+								<Tooltip title={<span className="whitespace-pre-line">
+									{`Stats
+										MAPE:
+										The Mean Absolute Percentage Error is the average forecast absolute error scaled to percentage units, where absolute errors allow to avoid the positive and negative errors cancelling.
+										R-Squared:
+										The R-Squared also known as coefficient of determination is the proportion of the variation between the forecasted valuations and actual selling prices. It ranges from 0 to 1 where 1 indicates the forcasted values match perfectly with actual values.
+										Maximum:
+										Maximum forecasted value that the trained model returns
+										Minimum:
+										Minimum forecasted value that the trained model returns
+									`}
+								</span>}
+									placement="bottom-start"
+									arrow
+								>
+									<div>
+										<AiFillQuestionCircle className='text-grey-icon hover:text-grey-content cursor-pointer transition-all duration-300' />
+									</div>
+								</Tooltip>
+							</div>
 							<p className="font-medium">The MGH LAND price estimator uses AI to calculate the fair value of LANDs and help you find undervalued ones.  Leverage our heatmap to quickly get an overview of {metaverseLabels[metaverse]} Map and get insights about current price trends. The valuations are updated at a daily basis.</p>
 						</div>
 						<div className="flex space-x-8 w-full items-center justify-evenly max-w-2xl">
@@ -553,12 +576,12 @@ const Valuation: NextPage<{ prices: ICoinPrices }> = ({ prices }) => {
 						<>
 							<div className="flex items-center justify-center p-8 mt-7">
 								<div className="flex flex-col justify-center space-y-3 max-w-xl text-center">
-									<p className="text-grey-content font-bold lg:text-3xl text-2xl text-center">{metaverseLabels[metaverse]} Floor Listings <Image src='/images/icons/hot-icon.svg' width={24} height={26} alt="Hot Deals" className=''/></p>
+									<p className="text-grey-content font-bold lg:text-3xl text-2xl text-center">{metaverseLabels[metaverse]} Floor Listings <Image src='/images/icons/hot-icon.svg' width={24} height={26} alt="Hot Deals" className='' /></p>
 									<p className="font-medium text-cente">Undervalued floor listings</p>
 								</div>
 							</div>
 							<div className="flex items-center justify-center p-8 mt-7">
-								<HotDeals metaverse={metaverse}/>
+								<HotDeals metaverse={metaverse} />
 							</div>
 						</>
 					)}


### PR DESCRIPTION
Added tooltip explanation on land valuation metaverse title:

![image](https://user-images.githubusercontent.com/54643793/236574254-4acb1beb-e2c7-49b1-85a3-a2ba5fa2ffad.png)

And add the same data on map card our price estimation:

![image](https://user-images.githubusercontent.com/54643793/236574323-a181f777-d74e-433c-b5d6-9aabf5d8602f.png)
